### PR TITLE
Keep dtbs hierarchy as upstream

### DIFF
--- a/rock5b/linux-rockchip-bsp5/PKGBUILD
+++ b/rock5b/linux-rockchip-bsp5/PKGBUILD
@@ -54,7 +54,8 @@ _package() {
   install -dm755 "$pkgdir/usr"
   
   # copy dtbs
-  cp -rf "usr/lib/linux-image-${_kernver}/rockchip/" "$pkgdir/boot/dtbs"
+  mkdir "$pkgdir/boot/dtbs"
+  cp -rf "usr/lib/linux-image-${_kernver}/rockchip/" "$pkgdir/boot/dtbs/rockchip"
 
   # copy modules
   cp -r lib "$pkgdir/usr/lib"


### PR DESCRIPTION
The dtbs should be placed under `rockchip` folder to make `devicetreedir` in `extlinux.conf` work. Currently we cannot just use a static path to dtbs in `extlinux.conf ` and have to manually change it for every kernel update, which is not convenient. 